### PR TITLE
Nav 컴포넌트 용도 변경

### DIFF
--- a/src/components/nav/Nav.tsx
+++ b/src/components/nav/Nav.tsx
@@ -1,42 +1,29 @@
 /** @jsxImportSource @emotion/react */
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { css } from '@emotion/react';
 import NavBtnBg from './NavBtnBg';
 import BtnContent from 'constants/BtnConstants';
 
 const NavStyle = css({
-    background: '#353535',
+    background: '#232427',
     height: '100vh',
-    width: '15rem',
+    width: '20vw',
     padding: '100px 30px',
     display: 'flex',
     flexDirection: 'column',
     alignItems: 'flex-start',
     gap: '25px',
-    isolation: 'isolate',
+    position: 'sticky',
+    top: '0px',
 });
-
-export interface NavPurposeType {
-    purpose: string;
-}
-
-type NavProps = {
-    navPurpose: NavPurposeType;
-};
 
 export interface NavBtnType {
     title: string;
     url: string;
 }
 
-const Nav = ({ navPurpose }: NavProps) => {
-    const { purpose } = navPurpose;
-    const [btnContent, setBtnContent] = useState<NavBtnType[]>([]);
-    useEffect(() => {
-        if (purpose == 'Intro') {
-            setBtnContent(BtnContent.Intro);
-        } else setBtnContent(BtnContent.Main);
-    }, [purpose]);
+const Nav = () => {
+    const [btnContent, setBtnContent] = useState<NavBtnType[]>(BtnContent.Main);
 
     return (
         <div css={NavStyle}>

--- a/src/pages/Intro.tsx
+++ b/src/pages/Intro.tsx
@@ -1,22 +1,19 @@
 /** @jsxImportSource @emotion/react */
 import { useState } from 'react';
 import { css } from '@emotion/react';
-import Nav from 'components/nav/Nav';
-import { NavPurposeType } from 'components/nav/Nav';
+import Background from 'components/background/Background';
 
 const IntroStyle = css({
     width: '100vw',
     height: '100vh',
+    display: 'flex',
+    flexDirection: 'row',
 });
 
 const Intro = () => {
-    const [navPurpose, setNavPurpose] = useState<NavPurposeType>({
-        purpose: 'Intro',
-    });
-
     return (
         <div css={IntroStyle}>
-            <Nav navPurpose={navPurpose}></Nav>
+            <Background></Background>
         </div>
     );
 };

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -1,15 +1,12 @@
+/** @jsxImportSource @emotion/react */
 import { useState } from 'react';
+import { css } from '@emotion/react';
 import Nav from 'components/nav/Nav';
-import { NavPurposeType } from 'components/nav/Nav';
 
 const Main = () => {
-    const [navPurpose, setNavPurpose] = useState<NavPurposeType>({
-        purpose: 'Main',
-    });
-
     return (
         <div>
-            <Nav navPurpose={navPurpose}></Nav>
+            <Nav></Nav>
         </div>
     );
 };


### PR DESCRIPTION
1. 변경 사유: Intro, Main 페이지 별로 다른 유형의 내브바 사용 필요
	- 원래 같은 Nav 컴포넌트를 활용할 예정이었으나, 내용이 적은 Intro 페이지에는 좌측 Nav가 아닌 상단 바를 사용하기로 함.
	- 변경 후가 페이지 목적에 보다 부합할 것으로 생각됨.
2. 용도 변경에 따른 구현 변경 사항
	- 더 이상 Nav의 내용을 상위 컴포넌트가 지정해줄 필요가 없으므로, 관련 props 및 타입 삭제.