### PR TITLE
IntroContainer, IntroText 컴포넌트 구현, 공통 css 파일 수정

### DIFF
--- a/src/components/intro-text/IntroContainer.tsx
+++ b/src/components/intro-text/IntroContainer.tsx
@@ -1,0 +1,26 @@
+/** @jsxImportSource @emotion/react */
+import { css } from '@emotion/react';
+import IntroText from './IntroText';
+
+const introContainerStyle = css({
+    color: 'white',
+    display: 'flex',
+    position: 'relative',
+    flexDirection: 'column',
+    '-webkit-box-pack': 'center',
+    justifyContent: 'center',
+    '-webkit-box-align': 'center',
+    alignItems: 'center',
+    height: '100vh',
+    width: 'fit-in-content',
+});
+
+const IntroContainer = () => {
+    return (
+        <div css={introContainerStyle}>
+            <IntroText></IntroText>
+        </div>
+    );
+};
+
+export default IntroContainer;

--- a/src/components/intro-text/IntroText.tsx
+++ b/src/components/intro-text/IntroText.tsx
@@ -1,0 +1,59 @@
+/** @jsxImportSource @emotion/react */
+import { css } from '@emotion/react';
+import IntroConstants from 'constants/IntroConstants';
+import fadinSliding from 'styles/Animations';
+
+const introTitleStyle = css({
+    color: 'white',
+    fontSize: 35,
+    fontWeight: 600,
+    display: 'flex',
+    position: 'relative',
+    flexDirection: 'column',
+    '-webkit-box-pack': 'center',
+    justifyContent: 'center',
+    '-webkit-box-align': 'center',
+    alignItems: 'center',
+    margin: '10px',
+});
+
+const introBodyStyle = css({
+    color: 'white',
+    fontSize: 18,
+    fontWeight: 600,
+});
+
+const IntroText = () => {
+    return (
+        <>
+            <span css={introTitleStyle}>
+                <p
+                    css={css`
+                        animation: ${fadinSliding} 0.7s ease both;
+                    `}
+                >
+                    {IntroConstants.IntroTitle1}
+                </p>
+                <p
+                    css={css`
+                        animation: ${fadinSliding} 0.7s ease 1s both;
+                    `}
+                >
+                    {IntroConstants.IntroTitle2}
+                </p>
+            </span>
+            <span
+                css={css`
+                    animation: ${fadinSliding} 0.7s ease 2s both;
+                    ${introBodyStyle}
+                `}
+            >
+                <p>{IntroConstants.IntroBody1}</p>
+                <p>{IntroConstants.IntroBody2}</p>
+                <p>{IntroConstants.IntroBody3}</p>
+            </span>
+        </>
+    );
+};
+
+export default IntroText;

--- a/src/constants/IntroConstants.ts
+++ b/src/constants/IntroConstants.ts
@@ -1,0 +1,9 @@
+const IntroConstants = {
+    IntroTitle1: '배우고 나아가는',
+    IntroTitle2: '전해연입니다.',
+    IntroBody1: '스타트업 기획자에서, 프론트엔드 개발자가 되었습니다.',
+    IntroBody2: '문제를 해결하고, 기술에 얽매이지 않는 개발을 좋아합니다.',
+    IntroBody3: '고민 있는 코드 작성과 좋은 커뮤니케이션을 추구합니다.',
+};
+
+export default IntroConstants;

--- a/src/pages/Intro.tsx
+++ b/src/pages/Intro.tsx
@@ -2,18 +2,21 @@
 import { useState } from 'react';
 import { css } from '@emotion/react';
 import Background from 'components/background/Background';
+import IntroTitle from 'components/intro-text/IntroText';
+import IntroContainer from 'components/intro-text/IntroContainer';
 
 const IntroStyle = css({
     width: '100vw',
     height: '100vh',
     display: 'flex',
-    flexDirection: 'row',
+    flexDirection: 'column',
 });
 
 const Intro = () => {
     return (
         <div css={IntroStyle}>
             <Background></Background>
+            <IntroContainer></IntroContainer>
         </div>
     );
 };

--- a/src/styles/Animations.tsx
+++ b/src/styles/Animations.tsx
@@ -1,0 +1,16 @@
+import { keyframes } from '@emotion/react';
+
+// 슬라이드- 페이드인 애니메이션
+
+const fadinSliding = keyframes({
+    from: {
+        opacity: 0,
+        top: '-2%',
+    },
+    to: {
+        opacity: 1,
+        top: '0%',
+    },
+});
+
+export default fadinSliding;

--- a/src/styles/Default.tsx
+++ b/src/styles/Default.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/react';
 
 const Default = css({
+    // 기본 폰트
     '@font-face': [
         {
             'font-family': 'S-CoreDream-3Light',
@@ -10,6 +11,13 @@ const Default = css({
         },
     ],
     fontFamily: 'S-CoreDream-3Light',
+
+    p: {
+        position: 'relative',
+        margin: '13px',
+    },
+
+    // 미디어 쿼리
 });
 
 export default Default;


### PR DESCRIPTION
1. 구현 세부 사항
   - Intro 페이지에 담길 텍스트와 관련된 컴포넌트
   - IntroContainer가 텍스트를 담는 container, IntroText가 실제 text로 기능
   - 텍스트는 src/constants/IntroContants에 상수화
2. css 적용 사항
   - animation 적용 (fadein, sliding)
   - p태그 사용에 따라, 공통 css 파일(src/styles/Default)에 관련 css 추가