### PR TITLE
useLinktoPage의 셀렉터 변경

### DIFF
--- a/src/components/header/HeaderButtons.tsx
+++ b/src/components/header/HeaderButtons.tsx
@@ -24,7 +24,7 @@ const HeaderButtons = ({ prop }: buttonType) => {
     }, [title, url]);
 
     return (
-        <div className={title}>
+        <div id={title}>
             <Button variant='text' size='large' css={buttonStyle}>
                 {title}
             </Button>

--- a/src/hooks/useLinkToPage.tsx
+++ b/src/hooks/useLinkToPage.tsx
@@ -1,4 +1,7 @@
 export const useLinkToPage = (title: string, url: string) => {
-    const buttonDiv = document.querySelector(`.${title}`);
-    buttonDiv?.addEventListener('click', () => window.open(url));
+    const buttonDiv = document.getElementById(`${title}`);
+    buttonDiv?.addEventListener('click', (e) => {
+        e.preventDefault();
+        window.open(url);
+    });
 };


### PR DESCRIPTION
1. 문제 상황
	- 일부 컴포넌트에서 전달하는 title props가 기존 셀렉터로 선택할 수 없는 현상
2. 원인
	- 셀렉터가 읽을 수 없는 특수문자가 전달되었기 때문
	- 괄호가 문제였던 것으로 추정
3. 해결
	- string만으로 이루어진 변수만들어 셀렉터에 사용하도록 함
	- 추가로, 단 하나의 element에 적용되므로 getElementById를 사용하도록 변경