### PR TITLE
Section 컴포넌트 Activity, Project로 분리

### DIFF
--- a/src/components/article/Article.tsx
+++ b/src/components/article/Article.tsx
@@ -1,7 +1,7 @@
 /** @jsxImportSource @emotion/react */
 import { css } from '@emotion/react';
 import ArticleDetail from './ArticleDetail';
-import { ArticlePropsType } from './Section';
+import { ArticlePropsType } from '../section/Activity';
 import { useEffect, useState } from 'react';
 import SkillsTab from 'components/tabs/SkillsTab';
 import ArticleGithubUrl from './ArticleGithubUrl';

--- a/src/components/section/Activity.tsx
+++ b/src/components/section/Activity.tsx
@@ -1,18 +1,19 @@
 /** @jsxImportSource @emotion/react */
-import { useEffect, useState } from 'react';
+import { useEffect, useState, forwardRef } from 'react';
 import { css } from '@emotion/react';
 import Article from 'components/article/Article';
 import SectionTitle from './SectionTitle';
 import { sectionType } from 'pages/Main';
-import { Project } from 'constants/ArticleConstants';
-import { Activity } from 'constants/ArticleConstants';
+import { ACTIVITY } from 'constants/ArticleConstants';
 import { BACKGROUND } from 'styles/Colors';
 import { TabPanelProps } from 'components/tabs/SkillsTab';
+import { useRecoilState } from 'recoil';
+import { activityState } from 'recoil/atoms/navState';
 
 const sectionStyle = css({
     display: 'flex',
     height: 'fit-content',
-    width: '80vw',
+    width: '100vw',
     backgroundColor: `${BACKGROUND}`,
     position: 'relative',
     flexDirection: 'column',
@@ -22,6 +23,7 @@ const sectionStyle = css({
 
 export interface SectionPropsType {
     sectionProps: sectionType;
+    ref: React.MutableRefObject<HTMLDivElement>;
 }
 
 export interface ArticlePropsType {
@@ -35,24 +37,21 @@ export interface ArticlePropsType {
     tabLables?: string[];
 }
 
-const Section = ({ sectionProps }: SectionPropsType) => {
+const Activity = forwardRef(({ sectionProps, ref }: SectionPropsType) => {
     const { type } = sectionProps;
     const [articleProps, setArticleProps] = useState<ArticlePropsType[]>([]);
     useEffect(() => {
-        if (type == 'PROJECT') {
-            setArticleProps(Project);
-        } else {
-            setArticleProps(Activity);
-        }
+        setArticleProps(ACTIVITY);
     }, [type]);
+
     return (
-        <section css={sectionStyle}>
-            <SectionTitle sectionProps={sectionProps}></SectionTitle>
+        <section css={sectionStyle} ref={ref}>
+            <SectionTitle type={type}></SectionTitle>
             {articleProps.map((articleProp) => (
                 <Article articleProp={articleProp} />
             ))}
         </section>
     );
-};
+});
 
-export default Section;
+export default Activity;

--- a/src/components/section/Project.tsx
+++ b/src/components/section/Project.tsx
@@ -1,0 +1,54 @@
+/** @jsxImportSource @emotion/react */
+import { useEffect, useState, forwardRef } from 'react';
+import { css } from '@emotion/react';
+import Article from 'components/article/Article';
+import SectionTitle from './SectionTitle';
+import { sectionType } from 'pages/Main';
+import { PROJECT } from 'constants/ArticleConstants';
+import { BACKGROUND } from 'styles/Colors';
+import { TabPanelProps } from 'components/tabs/SkillsTab';
+
+const sectionStyle = css({
+    display: 'flex',
+    height: 'fit-content',
+    width: '100vw',
+    backgroundColor: `${BACKGROUND}`,
+    position: 'relative',
+    flexDirection: 'column',
+    padding: '5rem',
+    paddingBottom: '0rem',
+});
+
+export interface SectionPropsType {
+    sectionProps: sectionType;
+    ref: React.MutableRefObject<HTMLDivElement>;
+}
+
+export interface ArticlePropsType {
+    title: string;
+    githubUrl?: string;
+    subtitle: string;
+    term: string;
+    group: string;
+    detail: string[];
+    tabContents?: TabPanelProps[];
+    tabLables?: string[];
+}
+
+const Project = forwardRef(({ sectionProps, ref }: SectionPropsType) => {
+    const { type } = sectionProps;
+    const [articleProps, setArticleProps] = useState<ArticlePropsType[]>([]);
+    useEffect(() => {
+        setArticleProps(PROJECT);
+    }, [type]);
+    return (
+        <section css={sectionStyle} ref={ref}>
+            <SectionTitle type={type}></SectionTitle>
+            {articleProps.map((articleProp) => (
+                <Article articleProp={articleProp} />
+            ))}
+        </section>
+    );
+});
+
+export default Project;

--- a/src/components/section/SectionTitle.tsx
+++ b/src/components/section/SectionTitle.tsx
@@ -1,7 +1,8 @@
 /** @jsxImportSource @emotion/react */
 import { css } from '@emotion/react';
-import { SectionPropsType } from './Section';
+import { SectionPropsType } from './Activity';
 import { HIGHLITGHT } from 'styles/Colors';
+import { sectionType } from 'pages/Main';
 
 const sectionTitleStyle = css({
     position: 'relative',
@@ -12,8 +13,11 @@ const sectionTitleStyle = css({
     marginBottom: '4rem',
 });
 
-const SectionTitle = ({ sectionProps }: SectionPropsType) => {
-    const { type } = sectionProps;
+interface typeType {
+    type: string;
+}
+
+const SectionTitle = ({ type }: typeType) => {
     return <h1 css={sectionTitleStyle}>{type}</h1>;
 };
 


### PR DESCRIPTION
1. 컴포넌트 구조 개선 이유
	- Section 컴포넌트는 타입에 따라 Activity, Project로 나뉘어 렌더링 되는 구조
	- Activity, Project의 view가 유사하지만 다른 내용을 담고 있으며, 또한 추후 aside에서 ref로 각각을 참조해야 하므로 분리하기로 결정.