### PR TITLE
Aside에 scrollIntoView 추가

### DIFF
--- a/src/components/aside/Aside.tsx
+++ b/src/components/aside/Aside.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource @emotion/react */
-import { useState } from 'react';
+import { useState, useRef } from 'react';
 import { css } from '@emotion/react';
 import AsideBtnBg from './AsideBtnBg';
 import BtnContent from 'constants/BtnConstants';
@@ -24,16 +24,26 @@ export interface AsideBtnType {
     url: string;
 }
 
-const Aside = () => {
-    const [btnContent, setBtnContent] = useState<AsideBtnType[]>(
-        BtnContent.Main,
-    );
+interface AsidePropType {
+    onProjectClick: () => void;
+    onActivityClick: () => void;
+}
+
+const Aside = ({ onProjectClick, onActivityClick }: AsidePropType) => {
+    // const [btnContent, setBtnContent] = useState<AsideBtnType[]>(
+    //     BtnContent.Main,
+    // );
 
     return (
         <aside css={AsideStyle}>
-            {btnContent.map((btn) => (
-                <AsideBtnBg btn={btn} />
-            ))}
+            <AsideBtnBg
+                btn={BtnContent.Main[1]}
+                event={onProjectClick}
+            ></AsideBtnBg>
+            <AsideBtnBg
+                btn={BtnContent.Main[2]}
+                event={onActivityClick}
+            ></AsideBtnBg>
         </aside>
     );
 };

--- a/src/components/aside/AsideBtnBg.tsx
+++ b/src/components/aside/AsideBtnBg.tsx
@@ -2,6 +2,7 @@
 import { css } from '@emotion/react';
 import { AsideBtnType } from './Aside';
 import { HIGHLITGHT } from 'styles/Colors';
+import { useRef } from 'react';
 
 const AsideBtnStyle = css({
     fontSize: 18,
@@ -13,19 +14,14 @@ const AsideBtnStyle = css({
 });
 
 type AsideBtnProps = {
-    btn: AsideBtnType;
+    btn: string;
+    event: () => void;
 };
 
-const AsideBtnBg = ({ btn }: AsideBtnProps) => {
-    const { title, url } = btn;
-
-    const useLink = () => {
-        window.open(url);
-    };
-
+const AsideBtnBg = ({ btn, event }: AsideBtnProps) => {
     return (
-        <div css={AsideBtnStyle} onClick={useLink}>
-            {title}
+        <div css={AsideBtnStyle} onClick={event}>
+            {btn}
         </div>
     );
 };

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -1,8 +1,9 @@
 /** @jsxImportSource @emotion/react */
-import { useState } from 'react';
+import { useState, useRef } from 'react';
 import { css } from '@emotion/react';
-import Nav from 'components/aside/Aside';
-import Section from 'components/article/Section';
+import Aside from 'components/aside/Aside';
+import Project from 'components/section/Project';
+import Activity from 'components/section/Activity';
 
 const mainStyle = css({
     display: 'flex',
@@ -25,12 +26,30 @@ const Main = () => {
     const [articleProps, setArticleProps] = useState<sectionType>({
         type: 'ACTIVITY',
     });
+
+    const onProjectClick = () => {
+        projectRef.current?.scrollIntoView({ behavior: 'smooth' });
+    };
+
+    const onActivityClick = () => {
+        activityRef.current?.scrollIntoView({ behavior: 'smooth' });
+    };
+
+    const projectRef = useRef<HTMLDivElement>(null);
+    const activityRef = useRef<HTMLDivElement>(null);
+
     return (
         <div css={mainStyle}>
-            <Nav></Nav>
+            {/* <Aside
+                onProjectClick={onProjectClick}
+                onActivityClick={onActivityClick}
+            ></Aside> */}
             <section css={mainSectionStyle}>
-                <Section sectionProps={projectProps}></Section>
-                <Section sectionProps={articleProps}></Section>
+                <Project sectionProps={projectProps} ref={projectRef}></Project>
+                <Activity
+                    sectionProps={articleProps}
+                    ref={activityRef}
+                ></Activity>
             </section>
         </div>
     );


### PR DESCRIPTION
1. 기능 주요 내용
	- scrollIntoView: 지정한 element로 스크롤 뷰를 이동하는 메서드
	- useRef, forwardRef를 이용하여 다른 컴포넌트의 DOM 객체에 접근한 뒤, props로 넘겨 받아 대상 element로 사용

2. 주의 사항
	- props drilling 이슈 해결을 위해 recoil 도입 예정이므로, props로 주고받는 방식 변경 필요
	- useRef를 하드코딩하여 구현하고 있는 점을 더 효율적으로 바꿀 방법 필요