### PR TITLE
불필요한 props 전달, 타입 선언 중복 해결

### DIFF
--- a/src/components/article/Article.tsx
+++ b/src/components/article/Article.tsx
@@ -1,10 +1,10 @@
 /** @jsxImportSource @emotion/react */
 import { css } from '@emotion/react';
 import ArticleDetail from './ArticleDetail';
-import { ArticlePropsType } from '../section/Activity';
 import { useEffect, useState } from 'react';
 import SkillsTab from 'components/tabs/SkillsTab';
 import ArticleGithubUrl from './ArticleGithubUrl';
+import { TabPanelProps } from 'components/tabs/SkillsTab';
 
 const articleStyle = css({
     display: 'flex',
@@ -22,6 +22,17 @@ const spanRowStyle = css({
     flexDirection: 'row',
     gap: '1rem',
 });
+
+export interface ArticlePropsType {
+    title: string;
+    githubUrl?: string;
+    subtitle: string;
+    term: string;
+    group: string;
+    detail: string[];
+    tabContents?: TabPanelProps[];
+    tabLables?: string[];
+}
 
 interface ArticlePropType {
     articleProp: ArticlePropsType;

--- a/src/components/section/Activity.tsx
+++ b/src/components/section/Activity.tsx
@@ -3,10 +3,11 @@ import { useEffect, useState, forwardRef } from 'react';
 import { css } from '@emotion/react';
 import Article from 'components/article/Article';
 import SectionTitle from './SectionTitle';
-import { sectionType } from 'pages/Main';
+import { TYPE } from 'constants/SectionTypeConstants';
 import { ACTIVITY } from 'constants/ArticleConstants';
 import { BACKGROUND } from 'styles/Colors';
-import { TabPanelProps } from 'components/tabs/SkillsTab';
+import { ArticlePropsType } from 'components/article/Article';
+import { SectionPropsType } from 'pages/Main';
 
 const sectionStyle = css({
     display: 'flex',
@@ -19,32 +20,15 @@ const sectionStyle = css({
     paddingBottom: '0rem',
 });
 
-export interface SectionPropsType {
-    sectionProps: sectionType;
-    ref: React.MutableRefObject<HTMLDivElement>;
-}
-
-export interface ArticlePropsType {
-    title: string;
-    githubUrl?: string;
-    subtitle: string;
-    term: string;
-    group: string;
-    detail: string[];
-    tabContents?: TabPanelProps[];
-    tabLables?: string[];
-}
-
-const Activity = forwardRef(({ sectionProps, ref }: SectionPropsType) => {
-    const { type } = sectionProps;
+const Activity = forwardRef(({ ref }: SectionPropsType) => {
     const [articleProps, setArticleProps] = useState<ArticlePropsType[]>([]);
     useEffect(() => {
         setArticleProps(ACTIVITY);
-    }, [type]);
+    }, []);
 
     return (
         <section css={sectionStyle} ref={ref}>
-            <SectionTitle type={type}></SectionTitle>
+            <SectionTitle type={TYPE.ACTIVITY}></SectionTitle>
             {articleProps.map((articleProp) => (
                 <Article articleProp={articleProp} />
             ))}

--- a/src/components/section/Project.tsx
+++ b/src/components/section/Project.tsx
@@ -3,10 +3,11 @@ import { useEffect, useState, forwardRef } from 'react';
 import { css } from '@emotion/react';
 import Article from 'components/article/Article';
 import SectionTitle from './SectionTitle';
-import { sectionType } from 'pages/Main';
+import { TYPE } from 'constants/SectionTypeConstants';
 import { PROJECT } from 'constants/ArticleConstants';
 import { BACKGROUND } from 'styles/Colors';
-import { TabPanelProps } from 'components/tabs/SkillsTab';
+import { SectionPropsType } from 'pages/Main';
+import { ArticlePropsType } from 'components/article/Article';
 
 const sectionStyle = css({
     display: 'flex',
@@ -19,31 +20,14 @@ const sectionStyle = css({
     paddingBottom: '0rem',
 });
 
-export interface SectionPropsType {
-    sectionProps: sectionType;
-    ref: React.MutableRefObject<HTMLDivElement>;
-}
-
-export interface ArticlePropsType {
-    title: string;
-    githubUrl?: string;
-    subtitle: string;
-    term: string;
-    group: string;
-    detail: string[];
-    tabContents?: TabPanelProps[];
-    tabLables?: string[];
-}
-
-const Project = forwardRef(({ sectionProps, ref }: SectionPropsType) => {
-    const { type } = sectionProps;
+const Project = forwardRef(({ ref }: SectionPropsType) => {
     const [articleProps, setArticleProps] = useState<ArticlePropsType[]>([]);
     useEffect(() => {
         setArticleProps(PROJECT);
-    }, [type]);
+    }, []);
     return (
         <section css={sectionStyle} ref={ref}>
-            <SectionTitle type={type}></SectionTitle>
+            <SectionTitle type={TYPE.PROJECT}></SectionTitle>
             {articleProps.map((articleProp) => (
                 <Article articleProp={articleProp} />
             ))}

--- a/src/components/section/SectionTitle.tsx
+++ b/src/components/section/SectionTitle.tsx
@@ -1,8 +1,6 @@
 /** @jsxImportSource @emotion/react */
 import { css } from '@emotion/react';
-import { SectionPropsType } from './Activity';
 import { HIGHLITGHT } from 'styles/Colors';
-import { sectionType } from 'pages/Main';
 
 const sectionTitleStyle = css({
     position: 'relative',

--- a/src/constants/SectionTypeConstants.ts
+++ b/src/constants/SectionTypeConstants.ts
@@ -1,0 +1,4 @@
+export const TYPE = {
+    PROJECT: 'PROJECT',
+    ACTIVITY: 'ACTIVITY',
+};

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -15,18 +15,11 @@ const mainSectionStyle = css({
     flexDirection: 'column',
 });
 
-export interface sectionType {
-    type: string;
+export interface SectionPropsType {
+    ref: React.MutableRefObject<HTMLDivElement>;
 }
 
 const Main = () => {
-    const [projectProps, setProjectProps] = useState<sectionType>({
-        type: 'PROJECT',
-    });
-    const [articleProps, setArticleProps] = useState<sectionType>({
-        type: 'ACTIVITY',
-    });
-
     const onProjectClick = () => {
         projectRef.current?.scrollIntoView({ behavior: 'smooth' });
     };
@@ -45,11 +38,8 @@ const Main = () => {
                 onActivityClick={onActivityClick}
             ></Aside> */}
             <section css={mainSectionStyle}>
-                <Project sectionProps={projectProps} ref={projectRef}></Project>
-                <Activity
-                    sectionProps={articleProps}
-                    ref={activityRef}
-                ></Activity>
+                <Project ref={projectRef}></Project>
+                <Activity ref={activityRef}></Activity>
             </section>
         </div>
     );


### PR DESCRIPTION
1. 불필요한 props 전달
	- 기존: Main 컴포넌트에서 Project, Activity 컴포넌트 호출 시 불필요한 props를 전달	- 해결: props 전달을 삭제하고, 호출된 컴포넌트에서 직접 상수를 호출(SectionTypeConstants.ts)하는 방식으로 변경
	- 변경 파일 목록: Main.tsx, Section.tsx, Project.tsx, Activity.tsx, SectionTypeConstants.ts(신규 생성)

2. 타입 선언 중복 (a. Main이 전달할 ref 타입)
	- 기존: Project, Activity 컴포넌트에서 각각 Article 컴포넌트에 전달할 ref 타입을 선언
	- 해결: Main 컴포넌트에 전달받은 ref타입을 선언하기로 하고, export 하여 자식 컴포넌트에서 사용
	- 변경 파일 목록: Main.tsx, Project.tsx, Activity.tsx

	(b. Project, Activity가 전달할 props 타입)
	- 기존: Project, Activity 컴포넌트에서 각각 Article 컴포넌트에 전달할 props 타입을 선언
	- 해결: Article 컴포넌트에 전달받은 props 타입을 선언하기로 하고, export 하여 부모 컴포넌트에서 사용
	- 변경 파일 목록: Project.tsx, Activity.tsx, SectionTitle.tsx