### PR TITLE
ArticleTitleUrl 구현

### DIFF
--- a/src/components/article/Article.tsx
+++ b/src/components/article/Article.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from 'react';
 import SkillsTab from 'components/tabs/SkillsTab';
 import ArticleGithubUrl from './ArticleGithubUrl';
 import { TabPanelProps } from 'components/tabs/SkillsTab';
+import ArticleTitleUrl from './ArticleTitleUrl';
 
 const articleStyle = css({
     display: 'flex',
@@ -21,10 +22,12 @@ const spanRowStyle = css({
     display: 'flex',
     flexDirection: 'row',
     gap: '1rem',
+    alignItems: 'center',
 });
 
 export interface ArticlePropsType {
     title: string;
+    url: string;
     githubUrl?: string;
     subtitle: string;
     term: string;
@@ -41,6 +44,7 @@ interface ArticlePropType {
 const Article = ({ articleProp }: ArticlePropType) => {
     const {
         title,
+        url,
         githubUrl,
         subtitle,
         term,
@@ -70,7 +74,7 @@ const Article = ({ articleProp }: ArticlePropType) => {
                 <span>
                     <h4>{group}</h4>
                     <span css={spanRowStyle}>
-                        <h2>{title}</h2>
+                        <ArticleTitleUrl title={title} url={url} />
                     </span>
                     <h4>{term}</h4>
                     <h4>{subtitle}</h4>
@@ -87,7 +91,7 @@ const Article = ({ articleProp }: ArticlePropType) => {
                 <span>
                     <h4>{group}</h4>
                     <span css={spanRowStyle}>
-                        <h2>{title}</h2>
+                        <ArticleTitleUrl title={title} url={url} />
                         <ArticleGithubUrl githubUrl={githubUrl} title={title} />
                     </span>
                     <h4>{term}</h4>

--- a/src/components/article/ArticleTitleUrl.tsx
+++ b/src/components/article/ArticleTitleUrl.tsx
@@ -1,0 +1,36 @@
+/** @jsxImportSource @emotion/react */
+import { useEffect } from 'react';
+import { css } from '@emotion/react';
+import Button from '@mui/material/Button';
+import { useLinkToPage } from 'hooks/useLinkToPage';
+import { BLACK } from 'styles/Colors';
+
+interface titleUrlType {
+    title: string;
+    url: string;
+}
+
+const articleTitleStyle = css({
+    fontSize: '25px',
+    margin: '1rem 0 1rem 0',
+    padding: '0.5rem 1rem 0.3rem 1rem',
+    fontFamily: 'S-CoreDream-3Light',
+    color: BLACK,
+    fontWeight: 600,
+    borderRadius: '2rem',
+});
+
+const ArticleTitleUrl = ({ title, url }: titleUrlType) => {
+    useEffect(() => {
+        useLinkToPage(title, url);
+    }, [title, url]);
+    return (
+        <div id={title}>
+            <Button variant='text' size='large' css={articleTitleStyle}>
+                {title}
+            </Button>
+        </div>
+    );
+};
+
+export default ArticleTitleUrl;

--- a/src/constants/ArticleConstants.ts
+++ b/src/constants/ArticleConstants.ts
@@ -1,6 +1,7 @@
 export const PROJECT = [
     {
         title: '포트폴리오 페이지',
+        url: 'https://haeyeon-portfolio.netlify.app/',
         githubUrl: 'https://github.com/hailey-hy/new-personal-portfolio',
         subtitle: '개인 포트폴리오로 활용할 웹페이지 (현재 페이지)',
         term: '2023.04',
@@ -41,6 +42,7 @@ export const PROJECT = [
     },
     {
         title: '개발 정원',
+        url: 'https://devroadmap.netlify.app/signin',
         githubUrl: 'https://github.com/hailey-hy/devroadmap-front',
         subtitle: '예비 개발자를 위한 개발 공부 다이어리 & 기록 공유 웹 서비스',
         term: '2022.06 ~ 08, 2023.04 ~',
@@ -79,6 +81,7 @@ export const PROJECT = [
 export const ACTIVITY = [
     {
         title: 'CS 스터디',
+        url: 'https://www.notion.so/CS-6d0707eb635a44128ebdc9024d0a8f24',
         subtitle: '운영체제, 네트워크 등의 computer science 과목 스터디',
         term: '2021.12 ~ 2022.05',
         group: '그룹 스터디',
@@ -88,6 +91,7 @@ export const ACTIVITY = [
     },
     {
         title: '알고리즘 문제 해결 스터디',
+        url: 'https://github.com/hailey-hy/Problem-Solving',
         subtitle: '백준 및 프로그래머스 알고리즘 문제 풀이 스터디',
         term: '2021.10 ~ 진행중',
         group: '개인 스터디',


### PR DESCRIPTION
1. 구현 주요 내용
	- ArticleTitleUrl: 각 Article의 Title에 해당하는 버튼으로, project의 url이나 activity의 깃헙/노션 링크로 이동됨
	- ArticleTitleUrl은 부모 컴포넌트인 Article에서 title, url props를 전달받음

2. 구현 세부 사항
	- mui의 text Button을 활용해 구현
	- useLinkToPage hook을 사용해 외부 사이트 이동