### PR TITLE
Aside 버튼의 스크롤 이벤트 추가

### DIFF
--- a/src/components/section/Activity.tsx
+++ b/src/components/section/Activity.tsx
@@ -8,7 +8,7 @@ import { ACTIVITY } from 'constants/ArticleConstants';
 import { ArticlePropsType } from 'components/article/Article';
 import { SectionPropsType } from 'pages/Main';
 
-const Activity = forwardRef(({ ref }: SectionPropsType) => {
+const Activity = forwardRef<HTMLDivElement, SectionPropsType>((props, ref) => {
     const [articleProps, setArticleProps] = useState<ArticlePropsType[]>([]);
     useEffect(() => {
         setArticleProps(ACTIVITY);

--- a/src/components/section/Project.tsx
+++ b/src/components/section/Project.tsx
@@ -8,11 +8,12 @@ import { PROJECT } from 'constants/ArticleConstants';
 import { SectionPropsType } from 'pages/Main';
 import { ArticlePropsType } from 'components/article/Article';
 
-const Project = forwardRef(({ ref }: SectionPropsType) => {
+const Project = forwardRef<HTMLDivElement, SectionPropsType>((props, ref) => {
     const [articleProps, setArticleProps] = useState<ArticlePropsType[]>([]);
     useEffect(() => {
         setArticleProps(PROJECT);
     }, []);
+
     return (
         <section css={sectionStyle} ref={ref}>
             <SectionTitle type={TYPE.PROJECT}></SectionTitle>

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource @emotion/react */
-import { useState, useRef } from 'react';
+import { useRef } from 'react';
 import { css } from '@emotion/react';
 import Aside from 'components/aside/Aside';
 import Project from 'components/section/Project';
@@ -8,6 +8,7 @@ import Activity from 'components/section/Activity';
 const mainStyle = css({
     display: 'flex',
     flexDirection: 'row',
+    width: '100vw',
 });
 
 const mainSectionStyle = css({
@@ -16,10 +17,13 @@ const mainSectionStyle = css({
 });
 
 export interface SectionPropsType {
-    ref: React.MutableRefObject<HTMLDivElement>;
+    props: any;
 }
 
 const Main = () => {
+    const projectRef = useRef<HTMLDivElement>(null);
+    const activityRef = useRef<HTMLDivElement>(null);
+
     const onProjectClick = () => {
         projectRef.current?.scrollIntoView({ behavior: 'smooth' });
     };
@@ -28,18 +32,15 @@ const Main = () => {
         activityRef.current?.scrollIntoView({ behavior: 'smooth' });
     };
 
-    const projectRef = useRef<HTMLDivElement>(null);
-    const activityRef = useRef<HTMLDivElement>(null);
-
     return (
         <div css={mainStyle}>
-            {/* <Aside
+            <Aside
                 onProjectClick={onProjectClick}
                 onActivityClick={onActivityClick}
-            ></Aside> */}
+            ></Aside>
             <section css={mainSectionStyle}>
-                <Project ref={projectRef}></Project>
-                <Activity ref={activityRef}></Activity>
+                <Project props={'props'} ref={projectRef}></Project>
+                <Activity props={'props'} ref={activityRef}></Activity>
             </section>
         </div>
     );


### PR DESCRIPTION
1. 주요 구현 내용
	- 부모 컴포넌트(Main)에서 자식 컴포넌트(Project, Activity)에 useRef를 사용하여 ref 객체 전달
	- 자식 컴포넌트에서 전달받은 ref 객체를 fowardRef를 통해 다시 부모 컴포넌트로 전달
	- 부모 컴포넌트에서 ref 객체의 current 프로퍼티를 통해 이벤트 생성 후, Aside 컴포넌트로 전달
	- Aside 버튼을 클릭하면 각 ref가 가리키는 DOM으로 스크롤이 이동

2. 주의사항
	- 현재 ref를 정상적으로 주고받기 위해 사용하지 않는 props를 함께 전달하고 있는 상황
	- 더 나은 방안이 없는지 확인 필요 (https://github.com/hailey-hy/new-personal-portfolio/issues/34 참고)