### PR TITLE
width 100%일때 가로 스크롤이 생기는 현상 수정, 기타 스타일 수정

### DIFF
--- a/src/components/aside/Aside.tsx
+++ b/src/components/aside/Aside.tsx
@@ -1,8 +1,7 @@
 /** @jsxImportSource @emotion/react */
-import { useState, useRef } from 'react';
 import AsideBtnBg from './AsideBtnBg';
 import BtnContent from 'constants/BtnConstants';
-import { asideStyle } from './Style';
+import { asideContainerStyle, asideStyle } from './Style';
 
 export interface AsideBtnType {
     title: string;
@@ -15,20 +14,18 @@ interface AsidePropType {
 }
 
 const Aside = ({ onProjectClick, onActivityClick }: AsidePropType) => {
-    // const [btnContent, setBtnContent] = useState<AsideBtnType[]>(
-    //     BtnContent.Main,
-    // );
-
     return (
         <aside css={asideStyle}>
-            <AsideBtnBg
-                btn={BtnContent.Main[1]}
-                event={onProjectClick}
-            ></AsideBtnBg>
-            <AsideBtnBg
-                btn={BtnContent.Main[2]}
-                event={onActivityClick}
-            ></AsideBtnBg>
+            <div css={asideContainerStyle}>
+                <AsideBtnBg
+                    btn={BtnContent.Main[1]}
+                    event={onProjectClick}
+                ></AsideBtnBg>
+                <AsideBtnBg
+                    btn={BtnContent.Main[2]}
+                    event={onActivityClick}
+                ></AsideBtnBg>
+            </div>
         </aside>
     );
 };

--- a/src/components/aside/Style.tsx
+++ b/src/components/aside/Style.tsx
@@ -12,17 +12,23 @@ const asideBtnStyle = css({
     },
 });
 
+const asideContainerStyle = css({
+    display: 'flex',
+    position: 'relative',
+    flexDirection: 'column',
+    justifyContent: 'start',
+    margin: 'auto',
+    height: '60vh',
+    gap: '25px',
+    top: '85px',
+});
+
 const asideStyle = css({
     background: `${BACKGROUND}`,
     height: '100vh',
     width: '20vw',
-    padding: '100px 30px',
-    display: 'flex',
-    flexDirection: 'column',
-    alignItems: 'flex-start',
-    gap: '25px',
     position: 'sticky',
     top: '0px',
     bottom: '100vh',
 });
-export { asideBtnStyle, asideStyle };
+export { asideBtnStyle, asideStyle, asideContainerStyle };

--- a/src/components/section/Style.tsx
+++ b/src/components/section/Style.tsx
@@ -6,7 +6,7 @@ import { HIGHLITGHT } from 'styles/Colors';
 const sectionStyle = css({
     display: 'flex',
     height: 'fit-content',
-    width: '100vw',
+    width: '80vw',
     backgroundColor: `${BACKGROUND}`,
     position: 'relative',
     flexDirection: 'column',

--- a/src/styles/Default.tsx
+++ b/src/styles/Default.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/react';
 
 const Default = css({
+    boxSizing: 'border-box',
     // 기본 폰트
     '@font-face': [
         {


### PR DESCRIPTION
### 1. width 100%일때 가로 스크롤이 생기는 현상 수정
- width를 계산할 때 패딩이나 마진값이 포함되지 않는 설정에서 width가 100%이거나 100vw인 영역에 padding이 추가되었기 때문
- box-sizing 설정을 border-box로 변경
-> width 계산에서 패딩이나 마진값을 포함하도록 함

### 2. 기타 스타일 수정
1. Aside 스타일 수정
    - aside에 직접 스타일을 적용하기 보다, 한차례 내부의 영역에 스타일을 적용하도록 함
2. Activity, Project 스타일 수정
    - 80vw로 맞추어 aside와 합하면 100vw가 되도록 함