### PR TITLE
Article 분할하여 ArticleTitleContainer로 구현

### DIFF
--- a/src/components/article/Article.tsx
+++ b/src/components/article/Article.tsx
@@ -6,6 +6,7 @@ import ArticleGithubUrl from './ArticleGithubUrl';
 import { TabPanelProps } from 'components/tabs/SkillsTab';
 import ArticleTitleUrl from './ArticleTitleUrl';
 import { articleStyle, spanRowStyle } from './Style';
+import ArticleTitleContainer from './ArticleTitleContainer';
 
 export interface ArticlePropsType {
     title: string;
@@ -50,9 +51,9 @@ const Article = ({ articleProp }: ArticlePropType) => {
             <article css={articleStyle}>
                 <span>
                     <h4>{group}</h4>
-                    <span css={spanRowStyle}>
+                    <ArticleTitleContainer>
                         <ArticleTitleUrl title={title} url={url} />
-                    </span>
+                    </ArticleTitleContainer>
                     <h4>{term}</h4>
                     <h4>{subtitle}</h4>
                 </span>
@@ -67,10 +68,10 @@ const Article = ({ articleProp }: ArticlePropType) => {
             <article css={articleStyle}>
                 <span>
                     <h4>{group}</h4>
-                    <span css={spanRowStyle}>
+                    <ArticleTitleContainer>
                         <ArticleTitleUrl title={title} url={url} />
                         <ArticleGithubUrl githubUrl={githubUrl} title={title} />
-                    </span>
+                    </ArticleTitleContainer>
                     <h4>{term}</h4>
                     <h4>{subtitle}</h4>
                 </span>

--- a/src/components/article/ArticleTitleContainer.tsx
+++ b/src/components/article/ArticleTitleContainer.tsx
@@ -1,0 +1,9 @@
+/** @jsxImportSource @emotion/react */
+import React from 'react';
+import { spanRowStyle } from './Style';
+
+const ArticleTitleContainer = ({ children }: { children: React.ReactNode }) => {
+    return <span css={spanRowStyle}>{children}</span>;
+};
+
+export default ArticleTitleContainer;


### PR DESCRIPTION
- Article내에서 가로 flex를 표현하는 영역을 분할하여 ArticleTitleContainer로 구현
- Article과 다른 스타일을 표현하고 있으므로 나누는 것이 클린하다고 생각