### PR TITLE
feat: ArticleDetail 중 링크 역할을 수행할 수 있는 ArticleDetailUrl 생성

### DIFF
--- a/src/components/article/ArticleDetail.tsx
+++ b/src/components/article/ArticleDetail.tsx
@@ -3,13 +3,15 @@ import { css } from '@emotion/react';
 import CircleIcon from '@mui/icons-material/Circle';
 import { HIGHLITGHT } from 'styles/Colors';
 import { articleDetailStyle, circleStyle } from './Style';
+import ArticleDetailUrl from './ArticleDetailUrl';
 
-interface detailType {
+export interface detailType {
     detail: string;
 }
 
 const ArticleDetail = ({ detail }: detailType) => {
-    return (
+    if(detail.includes('<')) return (<ArticleDetailUrl detail={detail}></ArticleDetailUrl>);
+    else return (
         <span css={articleDetailStyle}>
             <CircleIcon fontSize='small' css={circleStyle} />
             <h3>{detail}</h3>

--- a/src/components/article/ArticleDetailUrl.tsx
+++ b/src/components/article/ArticleDetailUrl.tsx
@@ -1,0 +1,30 @@
+/** @jsxImportSource @emotion/react */
+import { useEffect } from 'react';
+import { useLinkToPage } from 'hooks/useLinkToPage';
+import { detailType } from "./ArticleDetail";
+import CircleIcon from '@mui/icons-material/Circle';
+import { articleDetailStyle, circleStyle } from './Style';
+import Button from '@mui/material/Button';
+import { articleDetialUrlStyle } from './Style';
+import AttachmentIcon from '@mui/icons-material/Attachment';
+import { articleDetailClipStyle } from './Style';
+
+const ArticleDetailUrl =  ({detail}:detailType) => {
+    const title = detail.slice(detail.indexOf('>') + 1);
+    const url= detail.slice(1, detail.indexOf('>'))
+    console.log(url)
+
+    useEffect(() => {
+        useLinkToPage(title, url);
+    }, [title, url]);
+
+return (<span css={articleDetailStyle}>
+    <CircleIcon fontSize='small' css={circleStyle} />
+    <Button id={title} variant='text' size='medium' css={articleDetialUrlStyle}>
+    <h3>{title}</h3>
+    <AttachmentIcon color='disabled' css={articleDetailClipStyle}></AttachmentIcon>
+    </Button>
+    </span>)
+}
+
+export default ArticleDetailUrl;


### PR DESCRIPTION
### 1. ArticleDetailUrl 역할
 - ArticleDetail 중 다른 페이지 링크가 필요한 내용에 해당
 - useLinktoPage 훅 사용
 - ArticleDetail에서 detail props를 받아 문자열 처리 후 url 추출해 링크 연결